### PR TITLE
Expose qemu's root address space to plugins

### DIFF
--- a/include/qemu/qemu-plugin.h
+++ b/include/qemu/qemu-plugin.h
@@ -656,6 +656,8 @@ void qemu_plugin_flush_tb(void);
 int qemu_plugin_rw_memory_cpu(uint64_t address, uint8_t buffer[],
                               size_t buf_size, char write);
 
+void* qemu_plugin_get_address_space(void);
+
 /**
  * qemu_plugin_single_step() - Function to change single step behaviour from the
  *                             plugin.

--- a/plugins/core.c
+++ b/plugins/core.c
@@ -29,6 +29,7 @@
 #include "tcg/tcg-op.h"
 #include "plugin.h"
 #include "qemu/compiler.h"
+#include "exec/address-spaces.h"
 
 struct qemu_plugin_cb {
     struct qemu_plugin_ctx *ctx;
@@ -543,6 +544,10 @@ void qemu_plugin_user_postfork(bool is_child)
     } else {
         qemu_rec_mutex_unlock(&plugin.lock);
     }
+}
+
+void* qemu_plugin_get_address_space(void) {
+    return (void*)&address_space_memory;
 }
 
 

--- a/plugins/qemu-plugins.symbols
+++ b/plugins/qemu-plugins.symbols
@@ -47,4 +47,5 @@
   qemu_plugin_uninstall;
   qemu_plugin_vcpu_for_each;
   qemu_plugin_write_reg;
+  qemu_plugin_get_address_space;
 };


### PR DESCRIPTION
This PR adds a new function which exposes the root address space of qemu's emulation engine to the plugins. The address space is needed to find mapped memory regions inside archie's faultplugin. The regions can then be dumped an be used to initialize the state of the unicorn engine.